### PR TITLE
Fix warning

### DIFF
--- a/spec/controllers/static_controller_spec.rb
+++ b/spec/controllers/static_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe StaticController, type: :controller do
   describe 'POST' do
     describe 'achievement' do
       it 'returns http success' do
-        post :achievement, age: 34, love_achievements: 16
+        post :achievement, params: { age: 34, love_achievements: 16}
         expect(response).to be_success
         expect(response).to render_template(:jadge)
         expect(assigns(:judgment_result)).not_to be_nil
@@ -26,7 +26,7 @@ RSpec.describe StaticController, type: :controller do
 
     describe 'prospects' do
       it 'returns http success' do
-        post :prospect, love_prospects: 16
+        post :prospect, params: { love_prospects: 16 }
         expect(response).to be_success
         expect(response).to render_template(:jadge)
         expect(assigns(:judgment_result)).not_to be_nil


### PR DESCRIPTION
- ActionController::TestCase HTTP request methods will accept only keyword arguments in future Rails versions.