### PR TITLE
Fix deprecation warning

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
 
   # Configure static file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
-  config.static_cache_control = 'public, max-age=3600'
+  config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true


### PR DESCRIPTION
- `config.static_cache_control` is deprecated and will be removed in Rails 5.1.