### PR TITLE
Fix deprecation warning

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,6 @@ module LoveEquation
     config.i18n.default_locale = :ja
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
     config.public_file_server.enabled = true
   end
 end


### PR DESCRIPTION
- ActiveRecord::Base.raise_in_transactional_callbacks= is deprecated, has no effect and will be removed without replacement.