### PR TITLE
Upgrade Bootsnap from 1.16.0 to 1.17.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'jbuilder', '2.11.5'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '2.6.1', group: :doc
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '1.16.0', require: false
+gem 'bootsnap', '1.17.0', require: false
 gem 'json', '2.6.3'
 gem 'nokogiri', '1.15.4'
 gem 'psych', '5.1.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,7 @@ GEM
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
     bindex (0.8.1)
-    bootsnap (1.16.0)
+    bootsnap (1.17.0)
       msgpack (~> 1.2)
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
@@ -285,7 +285,7 @@ PLATFORMS
   x86_64-darwin-18
 
 DEPENDENCIES
-  bootsnap (= 1.16.0)
+  bootsnap (= 1.17.0)
   bootstrap-sass (= 3.4.1)
   coveralls (= 0.8.23)
   debug (= 1.8.0)


### PR DESCRIPTION
close #726